### PR TITLE
Add a script to the Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ mypy = "^0.812"
 flake8 = "^3.9.1"
 isort = "^5.8.0"
 
+[tool.poetry.scripts]
+todo = "todo_txt.app:run"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This means that when the package is installed, pip will create an executable in the `bin` directory of the virtualenv.  See https://python-poetry.org/docs/pyproject/#scripts for more information.

In this case, running the following is enough:

```
poetry install
todo list
```

Running `python-m todo_txt` or `todo.sh` still works but is unnecessary with that modification.